### PR TITLE
Bump compatibility for Gnome 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/Tommimon/add-to-desktop",
   "uuid": "add-to-desktop@tommimon.github.com",


### PR DESCRIPTION
Tested with Fedora 43 beta, seems to work fine.